### PR TITLE
Remove onTouchStart attribute when used together with onMouseDown

### DIFF
--- a/src/TimeView.js
+++ b/src/TimeView.js
@@ -59,9 +59,9 @@ var DateTimePickerTime = onClickOutside( createClass({
 				}
 			}
 			return React.createElement('div', { key: type, className: 'rdtCounter' }, [
-				React.createElement('span', { key: 'up', className: 'rdtBtn', onTouchStart: this.onStartClicking('increase', type), onMouseDown: this.onStartClicking( 'increase', type ), onContextMenu: this.disableContextMenu }, '▲' ),
+				React.createElement('span', { key: 'up', className: 'rdtBtn', onMouseDown: this.onStartClicking( 'increase', type ), onContextMenu: this.disableContextMenu }, '▲' ),
 				React.createElement('div', { key: 'c', className: 'rdtCount' }, value ),
-				React.createElement('span', { key: 'do', className: 'rdtBtn', onTouchStart: this.onStartClicking('decrease', type), onMouseDown: this.onStartClicking( 'decrease', type ), onContextMenu: this.disableContextMenu }, '▼' )
+				React.createElement('span', { key: 'do', className: 'rdtBtn', onMouseDown: this.onStartClicking( 'decrease', type ), onContextMenu: this.disableContextMenu }, '▼' )
 			]);
 		}
 		return '';
@@ -69,9 +69,9 @@ var DateTimePickerTime = onClickOutside( createClass({
 
 	renderDayPart: function() {
 		return React.createElement('div', { key: 'dayPart', className: 'rdtCounter' }, [
-			React.createElement('span', { key: 'up', className: 'rdtBtn', onTouchStart: this.onStartClicking('toggleDayPart', 'hours'), onMouseDown: this.onStartClicking( 'toggleDayPart', 'hours'), onContextMenu: this.disableContextMenu }, '▲' ),
+			React.createElement('span', { key: 'up', className: 'rdtBtn', onMouseDown: this.onStartClicking( 'toggleDayPart', 'hours'), onContextMenu: this.disableContextMenu }, '▲' ),
 			React.createElement('div', { key: this.state.daypart, className: 'rdtCount' }, this.state.daypart ),
-			React.createElement('span', { key: 'do', className: 'rdtBtn', onTouchStart: this.onStartClicking('toggleDayPart', 'hours'), onMouseDown: this.onStartClicking( 'toggleDayPart', 'hours'), onContextMenu: this.disableContextMenu }, '▼' )
+			React.createElement('span', { key: 'do', className: 'rdtBtn', onMouseDown: this.onStartClicking( 'toggleDayPart', 'hours'), onContextMenu: this.disableContextMenu }, '▼' )
 		]);
 	},
 

--- a/test/__snapshots__/snapshots.spec.js.snap
+++ b/test/__snapshots__/snapshots.spec.js.snap
@@ -24,8 +24,7 @@ exports[`dateFormat set to false 1`] = `
                   <span
                     className="rdtBtn"
                     onContextMenu={[Function]}
-                    onMouseDown={[Function]}
-                    onTouchStart={[Function]}>
+                    onMouseDown={[Function]}>
                     ▲
                   </span>
                   <div
@@ -35,8 +34,7 @@ exports[`dateFormat set to false 1`] = `
                   <span
                     className="rdtBtn"
                     onContextMenu={[Function]}
-                    onMouseDown={[Function]}
-                    onTouchStart={[Function]}>
+                    onMouseDown={[Function]}>
                     ▼
                   </span>
                 </div>
@@ -49,8 +47,7 @@ exports[`dateFormat set to false 1`] = `
                   <span
                     className="rdtBtn"
                     onContextMenu={[Function]}
-                    onMouseDown={[Function]}
-                    onTouchStart={[Function]}>
+                    onMouseDown={[Function]}>
                     ▲
                   </span>
                   <div
@@ -60,8 +57,7 @@ exports[`dateFormat set to false 1`] = `
                   <span
                     className="rdtBtn"
                     onContextMenu={[Function]}
-                    onMouseDown={[Function]}
-                    onTouchStart={[Function]}>
+                    onMouseDown={[Function]}>
                     ▼
                   </span>
                 </div>
@@ -70,8 +66,7 @@ exports[`dateFormat set to false 1`] = `
                   <span
                     className="rdtBtn"
                     onContextMenu={[Function]}
-                    onMouseDown={[Function]}
-                    onTouchStart={[Function]}>
+                    onMouseDown={[Function]}>
                     ▲
                   </span>
                   <div
@@ -81,8 +76,7 @@ exports[`dateFormat set to false 1`] = `
                   <span
                     className="rdtBtn"
                     onContextMenu={[Function]}
-                    onMouseDown={[Function]}
-                    onTouchStart={[Function]}>
+                    onMouseDown={[Function]}>
                     ▼
                   </span>
                 </div>
@@ -7635,8 +7629,7 @@ exports[`viewMode set to time 1`] = `
                   <span
                     className="rdtBtn"
                     onContextMenu={[Function]}
-                    onMouseDown={[Function]}
-                    onTouchStart={[Function]}>
+                    onMouseDown={[Function]}>
                     ▲
                   </span>
                   <div
@@ -7646,8 +7639,7 @@ exports[`viewMode set to time 1`] = `
                   <span
                     className="rdtBtn"
                     onContextMenu={[Function]}
-                    onMouseDown={[Function]}
-                    onTouchStart={[Function]}>
+                    onMouseDown={[Function]}>
                     ▼
                   </span>
                 </div>
@@ -7660,8 +7652,7 @@ exports[`viewMode set to time 1`] = `
                   <span
                     className="rdtBtn"
                     onContextMenu={[Function]}
-                    onMouseDown={[Function]}
-                    onTouchStart={[Function]}>
+                    onMouseDown={[Function]}>
                     ▲
                   </span>
                   <div
@@ -7671,8 +7662,7 @@ exports[`viewMode set to time 1`] = `
                   <span
                     className="rdtBtn"
                     onContextMenu={[Function]}
-                    onMouseDown={[Function]}
-                    onTouchStart={[Function]}>
+                    onMouseDown={[Function]}>
                     ▼
                   </span>
                 </div>
@@ -7681,8 +7671,7 @@ exports[`viewMode set to time 1`] = `
                   <span
                     className="rdtBtn"
                     onContextMenu={[Function]}
-                    onMouseDown={[Function]}
-                    onTouchStart={[Function]}>
+                    onMouseDown={[Function]}>
                     ▲
                   </span>
                   <div
@@ -7692,8 +7681,7 @@ exports[`viewMode set to time 1`] = `
                   <span
                     className="rdtBtn"
                     onContextMenu={[Function]}
-                    onMouseDown={[Function]}
-                    onTouchStart={[Function]}>
+                    onMouseDown={[Function]}>
                     ▼
                   </span>
                 </div>


### PR DESCRIPTION
This PR is carried from @NicoDos PR [542](https://github.com/YouCanBookMe/react-datetime/pull/542).

We needed to move fast and hence we are carrying his PR here, merging it .

Thanks @NicoDos for the support. :)

